### PR TITLE
Update Go version to 1.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.18.8' # The Go version to download (if necessary) and use.
+          go-version: '^1.21.1' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
         run: make get-build-deps
       - name: Download required modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # docker run --rm -i -e WHO=bitnami bitnami/render-template <<<"hello {{WHO}}"
 #
-FROM golang:1.18-bullseye as build
+FROM golang:1.21-bullseye as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git make upx \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami/render-template
 
-go 1.18
+go 1.21
 
 require (
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aymerick/raymond v2.0.1+incompatible h1:ZhYb+Bw5DNBMAl/UpvbxXP7pALGiMzCAE56QwHPqjjk=
-github.com/aymerick/raymond v2.0.1+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/bitnami/gonit v0.1.0 h1:f0+5lCjX/1ar4iPrvlcE91TDE2nElxibNwvWXXy1sEU=
@@ -8,8 +6,6 @@ github.com/cesanta/errors v0.0.0-20160612174407-5adec772d663 h1:yxe0VAaLkwh7cXoC
 github.com/cesanta/errors v0.0.0-20160612174407-5adec772d663/go.mod h1:5V6uYRtJZjiJla602WCKuuB+JiHZDG1E3KOHWmBxr48=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/jessevdk/go-flags v1.3.0 h1:QmKsgik/Z5fJ11ZtlcA8F+XW9dNybBNFQ1rngF3MmdU=
-github.com/jessevdk/go-flags v1.3.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/juamedgod/cliassert v0.0.0-20180320011200-425256f2bb0b h1:j2GwaFh0vduPA3PilmBcsdWv0reobJHyIxGJnh9gIAA=


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Bump Golang version to 1.21.

### Benefits

Use a supported Golang branch.

### Possible drawbacks

Not expected.

