### PR TITLE
github-actions: Add gchat notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,3 +96,14 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  notify:
+    name: Send notification
+    needs:
+      - release
+    if: ${{ always() && needs.release.result == 'failure' }}
+    uses: bitnami/support/.github/workflows/gchat-notification.yml@main
+    with:
+      workflow: ${{ github.workflow }}
+      job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      webhook-url: ${{ secrets.GCHAT_CONTENT_ALERTS_WEBHOOK_URL }}


### PR DESCRIPTION
### Description of the change

This PR adds GChat notifications to the CD pipeline.

When the pipeline fails, it will notify the team with a message using the gchat-notification worflow from bitnami/support

### Possible drawbacks

None known.
