### PR TITLE
[bitnami/render-template] chore(workflows): Avoid running workflows in forked repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
             out/*.tar.gz
   release:
     needs: [ 'build-and-test' ]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'bitnami/render-template' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
### Description of the change

Check repository to avoid running scheduled or CD workflows in forked repositories.

### Benefits

Skip unnecessary executions and failures in forks.

### Possible drawbacks

None

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
